### PR TITLE
Add sparse set implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fetch
       - name: cargo test build
-        run: cargo build --tests
-      - run: cargo test
+        run: cargo build --tests --all-features
+      - run: cargo test --all-features
 
   publish-check:
     name: Publish Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## Unreleased
+
+- Adds sparse set + id implementation
+    - Adds `TypedSparseSet`, the main sparse set implementation + `NetworkedSet` which combines two
+    sparse sets with the same id type but different key spaces for the case of client + server
+    replication
+    - Adds `IdAllocator` for allocating ids into `TypedSparseSet`/`NetworkedSet`
+    - Adds `SetId` trait + `define_id!` macro to create your own id types
+
 ## `0.5.0`
 
 - `LinearMap::new` and `LinearSet::new` are now `const`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,12 +28,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "glam"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
 
 [[package]]
 name = "hashbrown"
@@ -47,6 +50,7 @@ dependencies = [
 name = "kollect"
 version = "0.5.0"
 dependencies = [
+ "bincode",
  "foldhash",
  "indexmap",
  "rustc-hash",
@@ -113,7 +117,6 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da1992073f0e55aab599f4483c460598219b4f9ff0affa124b33580ab511e25a"
 dependencies = [
- "glam",
  "memoffset",
  "speedy-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ zero_sized_map_values = "warn"
 default = []
 speedy = ["dep:speedy"]
 serde = ["dep:serde", "indexmap/serde"]
+test = ["serde", "speedy"]
 
 [dependencies]
 foldhash = "0.1"
@@ -104,8 +105,11 @@ serde = { version = "1.0.158", default-features = false, features = [
     "derive",
     "std",
 ], optional = true }
-speedy = { version = "0.8", optional = true, features = ["glam"] }
+speedy = { version = "0.8", optional = true }
 rustc-hash = "1.1.0"
+
+[dev-dependencies]
+bincode = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,10 @@ pub mod linear_set;
 #[doc(inline)]
 pub use linear_set::LinearSet;
 
+/// Provides the foundations of a "generational arena" / ECS-like storage, performing efficient
+/// mapping from a large linear key space to densely packed data.
+pub mod sparse_set;
+
 /// Type-alias of [`UnorderedMap`] that is useful when you are using keys that are [`NoHashable`]
 pub type UnorderedNoHashMap<K, V> = UnorderedMap<K, V, BuildNoHashHasher<K>>;
 

--- a/src/sparse_set.rs
+++ b/src/sparse_set.rs
@@ -136,7 +136,8 @@ where
         let data_ref = unsafe { &*self.data.get() };
         // SAFETY: Vec does not use niche optimizations and UnsafeCell has the same memory layout
         // as T so it should be safe to convert inbetween these representations.
-        let data_ref: &Vec<V> = unsafe { std::mem::transmute::<&Vec<UnsafeCell<V>>, &Vec<V>>(data_ref) };
+        let data_ref: &Vec<V> =
+            unsafe { std::mem::transmute::<&Vec<UnsafeCell<V>>, &Vec<V>>(data_ref) };
 
         let mut state = serializer.serialize_struct("TypedSparseSet", 3)?;
         state.serialize_field("sparse", &sparse_ref)?;
@@ -231,7 +232,9 @@ where
                             let data_tmp: Vec<V> = map.next_value()?;
                             // SAFETY: Vec does not use niche optimizations and UnsafeCell has the same memory layout
                             // as T so it should be safe to convert inbetween these representations.
-                            data = Some(unsafe { std::mem::transmute::<Vec<V>, Vec<UnsafeCell<V>>>(data_tmp) });
+                            data = Some(unsafe {
+                                std::mem::transmute::<Vec<V>, Vec<UnsafeCell<V>>>(data_tmp)
+                            });
                         }
                     }
                 }

--- a/src/sparse_set.rs
+++ b/src/sparse_set.rs
@@ -1,0 +1,955 @@
+use core::fmt::Debug;
+use std::cell::UnsafeCell;
+use std::num::NonZeroU32;
+use std::num::NonZeroUsize;
+
+use crate::specialized_hashers::BuildPrimitiveHasher;
+use crate::UnorderedPrimitiveMap;
+
+pub mod networked_set;
+pub mod id;
+
+pub use id::SetId;
+pub use id::RawId;
+
+/// Iterator over all `id`s and values in the set.
+pub struct SparseSetIter<'a, K: SetId, V> {
+    ids: std::iter::Chain<std::slice::Iter<'a, K>, std::slice::Iter<'a, K>>,
+    values:
+        std::iter::Chain<std::slice::Iter<'a, UnsafeCell<V>>, std::slice::Iter<'a, UnsafeCell<V>>>,
+}
+
+impl<'a, K: SetId, V> SparseSetIter<'a, K, V> {
+    fn new(sparseset: &'a TypedSparseSet<K, V>) -> Self {
+        // SAFETY: These accesses are guaranteed safe under normal borrowing rules (we are getting a shared ref through a shared ref).
+        // The only way to break it would be misuse of unsafe methods to get mutable refs through a shared ref, for example `get_mut_dyn``,
+        // in which case the caller of that unsafe method would have made the mistake, not the caller of this safe one.
+        let (dense, data) = unsafe { (&*sparseset.dense.get(), &*sparseset.data.get()) };
+
+        Self {
+            ids: dense.iter().chain([].iter()),
+            values: data.iter().chain([].iter()),
+        }
+    }
+
+    fn new_chained(first: &'a TypedSparseSet<K, V>, second: &'a TypedSparseSet<K, V>) -> Self {
+        // SAFETY: These accesses are guaranteed safe under normal borrowing rules (we are getting a shared ref through a shared ref).
+        // The only way to break it would be misuse of unsafe methods to get mutable refs through a shared ref, for example `get_mut_dyn``,
+        // in which case the caller of that unsafe method would have made the mistake, not the caller of this safe one.
+        let (dense, data) = unsafe { (&*first.dense.get(), &*first.data.get()) };
+        let (second_dense, second_data) = unsafe { (&*second.dense.get(), &*second.data.get()) };
+
+        Self {
+            ids: dense.iter().chain(second_dense.iter()),
+            values: data.iter().chain(second_data.iter()),
+        }
+    }
+}
+
+impl<'a, K: SetId, V> Iterator for SparseSetIter<'a, K, V> {
+    type Item = (K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // SAFETY: This access is guaranteed safe under normal borrowing rules (we are getting a shared ref through a shared ref).
+        // The only way to break it would be misuse of unsafe methods to get mutable refs through a shared ref, for example `get_mut_dyn``,
+        // in which case the caller of that unsafe method would have made the mistake, not the caller of this safe one.
+        let value = self.values.next().map(|a| unsafe { &*a.get() });
+        self.ids.next().copied().zip(value)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        min_size_hint(self.ids.size_hint(), self.values.size_hint())
+    }
+}
+
+/// Iterator over all `id`s and values in the set.
+pub struct SparseSetIterMut<'a, K: SetId, V> {
+    ids: std::iter::Chain<std::slice::IterMut<'a, K>, std::slice::IterMut<'a, K>>,
+    values: std::iter::Chain<
+        std::slice::IterMut<'a, UnsafeCell<V>>,
+        std::slice::IterMut<'a, UnsafeCell<V>>,
+    >,
+}
+
+impl<'a, K: SetId, V> SparseSetIterMut<'a, K, V> {
+    fn new(sparseset: &'a mut TypedSparseSet<K, V>) -> Self {
+        Self {
+            ids: sparseset.dense.get_mut().iter_mut().chain([].iter_mut()),
+            values: sparseset.data.get_mut().iter_mut().chain([].iter_mut()),
+        }
+    }
+
+    fn new_chained(
+        first: &'a mut TypedSparseSet<K, V>,
+        second: &'a mut TypedSparseSet<K, V>,
+    ) -> Self {
+        Self {
+            ids: first
+                .dense
+                .get_mut()
+                .iter_mut()
+                .chain(second.dense.get_mut().iter_mut()),
+            values: first
+                .data
+                .get_mut()
+                .iter_mut()
+                .chain(second.data.get_mut().iter_mut()),
+        }
+    }
+}
+
+impl<'a, K: SetId, V> Iterator for SparseSetIterMut<'a, K, V> {
+    type Item = (K, &'a mut V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = self.values.next().map(|a| a.get_mut());
+        self.ids.next().copied().zip(value)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        min_size_hint(self.ids.size_hint(), self.values.size_hint())
+    }
+}
+
+pub struct TypedSparseSet<K: SetId, V> {
+    sparse: UnsafeCell<SparseIndirectionTable>,
+    dense: UnsafeCell<Vec<K>>,
+    data: UnsafeCell<Vec<UnsafeCell<V>>>,
+}
+
+unsafe impl<K: SetId, V> Send for TypedSparseSet<K, V> {}
+unsafe impl<K: SetId, V> Sync for TypedSparseSet<K, V> {}
+
+#[cfg(feature = "serde")]
+impl<K: SetId, V> serde::Serialize for TypedSparseSet<K, V>
+where
+    V: serde::Serialize,
+    K: serde::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let sparse_ref = unsafe { &*self.sparse.get() };
+        let dense_ref = unsafe { &*self.dense.get() };
+        let data_ref = unsafe { &*self.data.get() };
+        let data_ref: &Vec<V> = unsafe { std::mem::transmute(data_ref) };
+
+        let mut state = serializer.serialize_struct("TypedSparseSet", 3)?;
+        state.serialize_field("sparse", &sparse_ref)?;
+        state.serialize_field("dense", &dense_ref)?;
+        state.serialize_field("data", &data_ref)?;
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, K: SetId, V> serde::Deserialize<'de> for TypedSparseSet<K, V>
+where
+    V: serde::Deserialize<'de>,
+    K: serde::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Sparse,
+            Dense,
+            Data,
+        }
+
+        struct TypedSparseSetVisitor<K: SetId, V>(
+            (std::marker::PhantomData<K>, std::marker::PhantomData<V>),
+        );
+
+        impl<'de, K: SetId + serde::Deserialize<'de>, V> serde::de::Visitor<'de> for TypedSparseSetVisitor<K, V>
+        where
+            V: serde::Deserialize<'de>,
+        {
+            type Value = TypedSparseSet<K, V>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct TypedSparseSet")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let sparse = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let dense = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                let data: Vec<V> = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(2, &self))?;
+                let data = unsafe { std::mem::transmute(data) };
+
+                Ok(TypedSparseSet {
+                    sparse: UnsafeCell::new(sparse),
+                    dense: UnsafeCell::new(dense),
+                    data: UnsafeCell::new(data),
+                })
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut sparse = None;
+                let mut dense = None;
+                let mut data = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Sparse => {
+                            if sparse.is_some() {
+                                return Err(serde::de::Error::duplicate_field("sparse"));
+                            }
+                            sparse = Some(map.next_value()?);
+                        }
+                        Field::Dense => {
+                            if dense.is_some() {
+                                return Err(serde::de::Error::duplicate_field("dense"));
+                            }
+                            dense = Some(map.next_value()?);
+                        }
+                        Field::Data => {
+                            if data.is_some() {
+                                return Err(serde::de::Error::duplicate_field("data"));
+                            }
+                            let data_tmp: Vec<V> = map.next_value()?;
+                            data = Some(unsafe { std::mem::transmute(data_tmp) });
+                        }
+                    }
+                }
+                let sparse = sparse.ok_or_else(|| serde::de::Error::missing_field("sparse"))?;
+                let dense = dense.ok_or_else(|| serde::de::Error::missing_field("dense"))?;
+                let data = data.ok_or_else(|| serde::de::Error::missing_field("data"))?;
+                Ok(TypedSparseSet {
+                    sparse: UnsafeCell::new(sparse),
+                    dense: UnsafeCell::new(dense),
+                    data: UnsafeCell::new(data),
+                })
+            }
+        }
+
+        const FIELDS: &[&str] = &["sparse", "dense", "data"];
+        deserializer.deserialize_struct(
+            "TypedSparseSet",
+            FIELDS,
+            TypedSparseSetVisitor((std::marker::PhantomData, std::marker::PhantomData)),
+        )
+    }
+}
+
+impl<K: SetId, T: Clone> Clone for TypedSparseSet<K, T> {
+    fn clone(&self) -> Self {
+        // SAFETY: Vec does not use niche optimizations and UnsafeCell has the same memory layout
+        // as T so it should be safe to convert inbetween these representations.
+        let data: &Vec<T> = unsafe {
+            let data_ref: &Vec<_> = &*self.data.get();
+            std::mem::transmute(data_ref)
+        };
+        let data_clone = data.clone();
+        unsafe {
+            // SAFETY: These accesses are guaranteed safe under normal borrowing rules.
+            // The only way to break it would be misuse of unsafe methods to get mutable refs through a shared ref.
+            Self {
+                sparse: UnsafeCell::new((*self.sparse.get()).clone()),
+                dense: UnsafeCell::new((*self.dense.get()).clone()),
+                // SAFETY: Vec does not use niche optimizations and UnsafeCell has the same memory layout
+                // as T so it should be safe to convert inbetween these representations.
+                data: UnsafeCell::new(std::mem::transmute(data_clone)),
+            }
+        }
+    }
+}
+
+impl<K: SetId, V> Default for TypedSparseSet<K, V> {
+    fn default() -> Self {
+        Self {
+            sparse: Default::default(),
+            dense: Default::default(),
+            data: Default::default(),
+        }
+    }
+}
+
+impl<K: SetId, V> TypedSparseSet<K, V> {
+    pub fn reserve(&mut self, capacity: usize) {
+        self.sparse.get_mut().values.reserve(capacity);
+        self.dense.get_mut().reserve(capacity);
+        self.data.get_mut().reserve(capacity);
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            sparse: UnsafeCell::new(SparseIndirectionTable::with_capacity(capacity)),
+            dense: UnsafeCell::new(Vec::with_capacity(capacity)),
+            data: UnsafeCell::new(Vec::with_capacity(capacity)),
+        }
+    }
+
+    /// Returns `true` if the sparse set contains a value for the given id.
+    #[inline]
+    pub fn contains_key(&self, id: K) -> bool {
+        // SAFETY: no API hands out borrows into `SparseIndirectionTable` meaning that no mutable aliases can exist.
+        unsafe { &*self.sparse.get() }.contains(id)
+    }
+
+    #[inline]
+    pub fn is_older_than_existing(&self, id: K) -> bool {
+        // SAFETY: no API hands out borrows into `SparseIndirectionTable` meaning that no mutable aliases can exist.
+        unsafe { &*self.sparse.get() }.is_older(id)
+    }
+
+    /// Clears the sparse set, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the sparse set.
+    pub fn clear(&mut self) {
+        self.sparse.get_mut().clear();
+        self.dense.get_mut().clear();
+        self.data.get_mut().clear();
+    }
+
+    /// Returns a reference to an element in the sparse set.
+    pub fn get(&self, id: K) -> Option<&V> {
+        // SAFETY: These accesses are guaranteed safe under normal borrowing rules (we are getting a shared ref through a shared ref).
+        // The only way to break it would be misuse of unsafe methods to get mutable refs through a shared ref, for example `get_mut_dyn``,
+        // in which case the caller of that unsafe method would have made the mistake, not the caller of this safe one.
+        let (sparse, data) = unsafe { (&*self.sparse.get(), &*self.data.get()) };
+
+        sparse.get_exact_version(id).map(|dense_index| {
+            // SAFETY: the spareset data structure ensures that the index is valid
+            let cell = unsafe { data.get_unchecked(dense_index) };
+
+            // SAFETY: This access is guaranteed safe under normal borrowing rules (we are getting a shared ref through a shared ref).
+            // The only way to break it would be misuse of unsafe methods to get mutable refs through a shared ref, for example `get_mut_dyn``,
+            // in which case the caller of that unsafe method would have made the mistake, not the caller of this safe one.
+            unsafe { &*cell.get() }
+        })
+    }
+
+    /// Returns a mutable reference to an element in the sparse set.
+    pub fn get_mut(&mut self, id: K) -> Option<&mut V> {
+        let sparse = self.sparse.get_mut();
+
+        sparse.get_exact_version(id).map(|dense_index| {
+            // SAFETY: the spareset data structure ensures that the index is valid.
+            let cell = unsafe { self.data.get_mut().get_unchecked_mut(dense_index) };
+
+            cell.get_mut()
+        })
+    }
+
+    /// Inserts the `id` key and `value` into this sparse set.
+    ///
+    /// Returns `true` when the *exact* key was already present in the sparse set
+    /// otherwise `false` (i.e. if overwrote an older version that still existed, return `false`).
+    ///
+    /// Will panic if the key is older than the existing key in the set.
+    /// Use `insert_ignore_old_key` if you want to silently skip insertion
+    /// for older keys instead of panicking.
+    #[inline(always)]
+    pub fn insert(&mut self, id: K, value: V) -> bool {
+        self.insert_impl(id, value, false)
+    }
+
+    /// Inserts the `id` key and `value` into this sparse set.
+    ///
+    /// Returns `true` when the *exact* key was already present in the sparse set
+    /// otherwise `false` (i.e. if overwrote an older version that still existed, return `false`).
+    ///
+    /// Use `insert` if you want to assert that the key is newer or the same
+    /// version as the exiting keys.
+    #[inline(always)]
+    pub fn insert_ignore_old_key(&mut self, id: K, value: V) -> bool {
+        self.insert_impl(id, value, true)
+    }
+
+    fn insert_impl(&mut self, id: K, value: V, ignore_old_keys: bool) -> bool {
+        assert!(!id.is_invalid());
+
+        let sparse = self.sparse.get_mut();
+
+        if let Some(dense_index) = sparse.get_older_or_exact_version(id) {
+            // SAFETY: We know this item exists.
+            unsafe {
+                sparse.bump_version_unchecked(id);
+            };
+
+            // Important:
+            // Version may have changed for this id index (i.e be a newer one),
+            // thus we need to update it in the "dense" map.
+            let old_key = self.dense.get_mut()[dense_index];
+            self.dense.get_mut()[dense_index] = id;
+            self.data.get_mut()[dense_index] = UnsafeCell::new(value);
+
+            // If we overwrote an older version, we return `false`
+            old_key.version() == id.version()
+        } else {
+            let success = sparse.set(id, self.dense.get_mut().len());
+
+            if !ignore_old_keys {
+                // If we tried to insert an older item we assert.
+                debug_assert!(success, "Tried to insert an older key! {id}");
+            }
+            if success {
+                self.dense.get_mut().push(id);
+                self.data.get_mut().push(UnsafeCell::new(value));
+            }
+
+            false
+        }
+    }
+
+    pub fn retain(&mut self, mut fun: impl FnMut(K, &mut V) -> bool) {
+        // This is shit
+        // TODO: Optimize :) (contributions welcome!)
+        let mut to_remove = Vec::new();
+        for (ent, val) in self.iter_mut() {
+            if !fun(ent, val) {
+                to_remove.push(ent);
+            }
+        }
+        for ent in to_remove {
+            self.remove(ent);
+        }
+    }
+
+    /// Removes the id from this sparse set and returns the removed element.
+    pub fn remove(&mut self, id: K) -> Option<V> {
+        let sparse = self.sparse.get_mut();
+
+        sparse.remove(id).map(|dense_index| {
+            let dense = self.dense.get_mut();
+
+            dense.swap_remove(dense_index);
+
+            if dense_index < dense.len() {
+                // If we don't end up in this block
+                // it means we removed the final element.
+                // there would be nothing in the sparse map to
+                // update.
+                //
+                // Otherwise we just update the sparse map to
+                // point to the right entry in the dense data.
+                let swapped_entity = dense[dense_index];
+                sparse.set(swapped_entity, dense_index);
+            }
+
+            self.data.get_mut().swap_remove(dense_index).into_inner()
+        })
+    }
+
+    /// Unsafely returns a mutable reference to an element in the sparse set.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that there is no *mutable* access to the entire `data` storage
+    /// as a whole (though there may be shared access), **and** that the access to the
+    /// specific id's data is unique (no active references, mutable or not).
+    #[inline]
+    pub unsafe fn get_mut_unchecked(&self, id: K) -> Option<&mut V> {
+        // SAFETY: no API hands out borrows into `SparseIndirectionTable` and there are no
+        // reentrant calls to `get_mut_unchecked` which means that the access is unique.
+        let sparse = unsafe { &*self.sparse.get() };
+
+        sparse.get_exact_version(id).map(|dense_index| {
+            // SAFETY: the caller must ensure that there is only shared access to the `data` array itself
+            let data = unsafe { &*self.data.get() };
+
+            // SAFETY: the spareset data structure ensures that the index is valid.
+            let cell = unsafe { data.get_unchecked(dense_index) };
+
+            // SAFETY: the caller must guarantee unique access to the value data, making this dereference safe.
+            unsafe { &mut *cell.get() }
+        })
+    }
+
+    /// Unsafely inserts the `id` key and `value` into this sparse set.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that access to the _entire_ `data` store as well as the `dense` id store are unique
+    /// (no active references, mutable or not). This is required as the insert can cause reallocations, making existing
+    /// references invalid.
+    #[inline]
+    pub unsafe fn insert_unchecked(&self, id: K, value: V) -> bool {
+        assert!(!id.is_invalid());
+
+        // SAFETY: no API hands out borrows into `SparseIndirectionTable` and there are no
+        // reentrant calls to `insert_unchecked` which means that the access is unique.
+        let sparse = unsafe { &mut *self.sparse.get() };
+
+        // SAFETY: the caller must guarantee that access to the entire `TypedSparseSet` is unique. As a result, dereferencing
+        // `self.dense` and `self.data` should be safe.
+        let (dense, data) = unsafe { (&mut *self.dense.get(), &mut *self.data.get()) };
+
+        if let Some(dense_index) = sparse.get_older_or_exact_version(id) {
+            // SAFETY: We know this item exists.
+            unsafe {
+                sparse.bump_version_unchecked(id);
+            };
+
+            // Important:
+            // Version may have changed for this id index (i.e be a newer one),
+            // thus we need to update it in the "dense" map.
+            let old_key = dense[dense_index];
+            dense[dense_index] = id;
+            data[dense_index] = UnsafeCell::new(value);
+
+            // If we overwrote an older version, we return `false`
+            old_key.version() == id.version()
+        } else {
+            let success = sparse.set(id, dense.len());
+
+            // If we tried to insert an older item we assert.
+            assert!(success, "Tried to insert an older id!");
+
+            dense.push(id);
+            data.push(UnsafeCell::new(value));
+
+            false
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.keys().is_empty()
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.keys().len()
+    }
+
+    #[inline]
+    pub fn keys(&self) -> &[K] {
+        // SAFETY: This access is guaranteed safe under normal borrowing rules (we are getting a shared ref through a shared ref).
+        // The only way to break it would be misuse of unsafe methods to get mutable refs through a shared ref, for example `get_mut_dyn``,
+        // in which case the caller of that unsafe method would have made the mistake, not the caller of this safe one.
+        unsafe { &*self.dense.get() }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> SparseSetIter<'_, K, V> {
+        SparseSetIter::new(self)
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.iter().map(|(_, v)| v)
+    }
+
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
+        self.iter_mut().map(|(_, v)| v)
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> SparseSetIterMut<'_, K, V> {
+        SparseSetIterMut::new(self)
+    }
+}
+
+/// We use `NonZeroUsize` so that the compiler optimizes the size of the
+/// option flag away.
+#[derive(Default, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+struct VersionAndDenseIndex {
+    // If this is `None` it means the element has never been used.
+    version: Option<NonZeroU32>,
+
+    // If this is `None` it means the element has either never
+    // been used or the data has been cleared.
+    dense_index: Option<NonZeroUsize>,
+}
+
+#[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+struct SparseIndirectionTable {
+    values: UnorderedPrimitiveMap<usize, VersionAndDenseIndex>,
+}
+
+impl SparseIndirectionTable {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            values: UnorderedPrimitiveMap::with_capacity_and_hasher(capacity, BuildPrimitiveHasher),
+        }
+    }
+    /// Returns `true` if the sparse array contains the index.
+    #[inline]
+    fn contains(&self, id: impl SetId) -> bool {
+        let index = id.index();
+
+        if let Some(VersionAndDenseIndex {
+            version: Some(version),
+            dense_index: Some(_),
+        }) = self.values.get(&index)
+        {
+            *version == id.version()
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn is_older(&self, id: impl SetId) -> bool {
+        let index = id.index();
+
+        if let Some(VersionAndDenseIndex {
+            version: Some(version),
+            dense_index: Some(_),
+        }) = self.values.get(&index)
+        {
+            *version > id.version()
+        } else {
+            false
+        }
+    }
+
+    /// Clears the sparse array, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the sparse set.
+    #[inline]
+    fn clear(&mut self) {
+        for v in self.values.values_mut() {
+            v.dense_index = None;
+        }
+    }
+
+    /// Gets an item given a comparator for the id vs slot version.
+    fn get<F: Fn(NonZeroU32, NonZeroU32) -> bool>(
+        &self,
+        id: impl SetId,
+        version_cmp: F,
+    ) -> Option<usize> {
+        // Perform a manual map to give the optimizer the best chance.
+        let index = id.index();
+
+        #[allow(clippy::manual_map)]
+        if let Some(VersionAndDenseIndex {
+            version: Some(version),
+            dense_index: Some(dense_index),
+        }) = self.values.get(&index)
+        {
+            version_cmp(id.version(), *version).then_some(dense_index.get() - 1)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the dense index mapped to the sparse index where the slot has to have a
+    /// version that is exactly equal to the id.
+    #[inline]
+    fn get_exact_version(&self, id: impl SetId) -> Option<usize> {
+        self.get(id, |entity_version, slot_version| {
+            entity_version == slot_version
+        })
+    }
+
+    /// Returns the dense index mapped to the sparse index where the slot has to have a
+    /// version that is exactly equal or older than the id.
+    #[inline]
+    fn get_older_or_exact_version(&self, id: impl SetId) -> Option<usize> {
+        self.get(id, |entity_version, slot_version| {
+            entity_version >= slot_version
+        })
+    }
+
+    /// Bumps version of an id
+    ///
+    /// # Safety
+    ///
+    /// The entry must exist
+    unsafe fn bump_version_unchecked(&mut self, id: impl SetId) {
+        // SAFETY: same as function level safety
+        unsafe {
+            self.values
+                .get_mut(&id.index())
+                .unwrap_unchecked()
+                .version = Some(id.version());
+        }
+    }
+
+    #[inline]
+    fn set(&mut self, id: impl SetId, dense_index: usize) -> bool {
+        let index = id.index();
+
+        // Perform a manual map to give the optimizer the best chance.
+        #[allow(clippy::manual_map)]
+        let dense_index = match NonZeroUsize::new(dense_index + 1) {
+            Some(i) => i,
+            None => overflowed_index(),
+        };
+
+        let entry = self.values.entry(index).or_default();
+
+        let version = if let Some(version) = entry.version {
+            version
+        } else {
+            id.version()
+        };
+
+        if id.version() >= version {
+            entry.version = Some(id.version());
+            entry.dense_index = Some(dense_index);
+            return true;
+        }
+
+        false
+    }
+
+    /// Removes and returns the dense index at position `index`.
+    #[inline]
+    fn remove(&mut self, id: impl SetId) -> Option<usize> {
+        // Perform a manual map to give the optimizer the best chance.
+        #[allow(clippy::manual_map)]
+        if let Some(VersionAndDenseIndex {
+            version: Some(version),
+            dense_index,
+        }) = self.values.get_mut(&id.index())
+        {
+            if *version == id.version() {
+                let prev_dense_index = (*dense_index)?;
+                *dense_index = None;
+                Some(prev_dense_index.get() - 1)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[cold]
+fn overflowed_index() -> ! {
+    panic!("dense_index + 1 overflowed")
+}
+
+#[inline]
+fn min_size_hint(a: (usize, Option<usize>), b: (usize, Option<usize>)) -> (usize, Option<usize>) {
+    // based on `std::iter::Zip::size_hint`
+    // https://github.com/rust-lang/rust/blob/65519f5fc0bcd8a47e547226bbc7498a2b9a59fb/library/core/src/iter/adapters/zip.rs#L209
+
+    let (a_lower, a_upper) = a;
+    let (b_lower, b_upper) = b;
+
+    let lower = std::cmp::min(a_lower, b_lower);
+
+    let upper = match (a_upper, b_upper) {
+        (Some(x), Some(y)) => Some(std::cmp::min(x, y)),
+        (Some(x), None) => Some(x),
+        (None, Some(y)) => Some(y),
+        (None, None) => None,
+    };
+
+    (lower, upper)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::define_id;
+    use super::id::IdAllocator;
+    use super::TypedSparseSet;
+
+    define_id! {
+        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        pub struct MyEntityId;
+    }
+
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    struct MyData {
+        value: u32,
+    }
+
+    fn new_ent_id(idx: usize, version: u32) -> MyEntityId {
+        MyEntityId::from_index_and_version(idx, version)
+    }
+
+    #[test]
+    #[should_panic]
+    pub fn test_sparse_set_inserting_older_item() {
+        let mut sparse_set: TypedSparseSet<MyEntityId, MyData> = TypedSparseSet::default();
+
+        let entity1_old = new_ent_id(0, 1);
+        let entity1_new = new_ent_id(0, 2);
+
+        let data1 = MyData { value: 0xfefefefe };
+
+        let already_present = sparse_set.insert(entity1_new, data1);
+        assert!(!already_present);
+
+        // This should panic as we try to insert an older id
+        let already_present = sparse_set.insert(entity1_old, data1);
+        assert!(!already_present);
+    }
+
+    #[test]
+    pub fn test_sparse_set_inserting_older_item_avoid_panic() {
+        let mut sparse_set: TypedSparseSet<MyEntityId, MyData> = TypedSparseSet::default();
+
+        let entity1_old = new_ent_id(0, 1);
+        let entity1_new = new_ent_id(0, 2);
+
+        let data1 = MyData { value: 0xfefefefe };
+
+        let already_present = sparse_set.insert_ignore_old_key(entity1_new, data1);
+        assert!(!already_present);
+
+        let already_present = sparse_set.insert_ignore_old_key(entity1_old, data1);
+        assert!(!already_present);
+    }
+
+    #[test]
+    pub fn test_sparse_set() {
+        let mut sparse_set: TypedSparseSet<MyEntityId, MyData> = TypedSparseSet::default();
+
+        let entity1_old = new_ent_id(0, 1);
+        let entity2_old = new_ent_id(1, 2);
+
+        let entity1_new = new_ent_id(0, 4);
+        let entity2_new = new_ent_id(1, 5);
+
+        let data1 = MyData { value: 0xfefefefe };
+        let data2 = MyData { value: 0xdeadbeef };
+
+        assert!(!sparse_set.contains_key(entity1_old));
+        assert!(!sparse_set.contains_key(entity1_new));
+        assert!(!sparse_set.contains_key(entity2_old));
+        assert!(!sparse_set.contains_key(entity2_new));
+
+        let already_present = sparse_set.insert(entity1_old, data1);
+        assert!(!already_present);
+
+        let already_present = sparse_set.insert(entity2_old, data1);
+        assert!(!already_present);
+
+        assert!(sparse_set.get(entity1_old) == Some(&data1));
+        assert!(sparse_set.get(entity1_new).is_none());
+        assert!(sparse_set.get(entity2_old) == Some(&data1));
+        assert!(sparse_set.get(entity2_new).is_none());
+
+        assert!(sparse_set.contains_key(entity1_old));
+        assert!(!sparse_set.contains_key(entity1_new));
+        assert!(sparse_set.contains_key(entity2_old));
+        assert!(!sparse_set.contains_key(entity2_new));
+
+        let removed = sparse_set.remove(entity1_old);
+        assert!(removed == Some(data1));
+
+        assert!(sparse_set.get(entity1_old).is_none());
+        assert!(sparse_set.get(entity1_new).is_none());
+        assert!(sparse_set.get(entity2_old) == Some(&data1));
+        assert!(sparse_set.get(entity2_new).is_none());
+
+        assert!(!sparse_set.contains_key(entity1_old));
+        assert!(!sparse_set.contains_key(entity1_new));
+        assert!(sparse_set.contains_key(entity2_old));
+        assert!(!sparse_set.contains_key(entity2_new));
+
+        let already_present = sparse_set.insert(entity2_new, data2);
+        assert!(!already_present);
+
+        assert!(sparse_set.get(entity2_old).is_none());
+        assert!(sparse_set.get(entity2_new) == Some(&data2));
+        assert!(!sparse_set.contains_key(entity2_old));
+        assert!(sparse_set.contains_key(entity2_new));
+
+        let already_present = sparse_set.insert(entity1_new, data1);
+        assert!(!already_present);
+
+        let entity_ids: Vec<(MyEntityId, &MyData)> = sparse_set.iter().collect();
+
+        assert!(entity_ids == vec![(entity2_new, &data2), (entity1_new, &data1)]);
+    }
+
+    #[test]
+    fn test_sparse_set_and_id_allocator() {
+        let mut set_a: TypedSparseSet<MyEntityId, MyData> = TypedSparseSet::default();
+        let mut set_b: TypedSparseSet<MyEntityId, String> = TypedSparseSet::default();
+        let mut alloc: IdAllocator<MyEntityId> = IdAllocator::new_client_or_standalone();
+
+        let entity_1 = alloc.allocate();
+        let entity_2 = alloc.allocate();
+
+        let str1 = String::from("yippee");
+        let data1 = MyData { value: 0xfefefefe };
+        let data2 = MyData { value: 0xdeadbeef };
+
+        set_a.insert(entity_1, data1.clone());
+        set_b.insert(entity_1, str1.clone());
+
+        assert_eq!(set_a.get(entity_1), Some(&data1));
+        assert_eq!(set_b.get(entity_1), Some(&str1));
+
+        set_a.insert(entity_2, data2.clone());
+
+        assert_eq!(set_a.get(entity_2), Some(&data2));
+        assert_eq!(set_b.get(entity_2), None);
+
+        eprintln!("{entity_1:?}");
+        eprintln!("{entity_2:?}");
+        eprintln!("{alloc:#?}");
+        assert!(alloc.remove(entity_1));
+
+        let entity_3 = alloc.allocate();
+        assert_eq!(entity_3.index(), 0);
+        assert_eq!(entity_3.version().get(), 2);
+
+        assert!(!set_a.contains_key(entity_3));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialize_roundtrip() {
+        let mut sparse_set: TypedSparseSet<MyEntityId, MyData> = TypedSparseSet::default();
+        let entity1 = new_ent_id(0, 1);
+        let entity2 = new_ent_id(1, 2);
+
+        let entity3 = new_ent_id(2, 4);
+        let entity4 = new_ent_id(3, 5);
+        let entity4_new = new_ent_id(3, 6);
+
+        let data1 = MyData { value: 0xfefefefe };
+        let data2 = MyData { value: 0xdeadbeef };
+        let data3 = MyData { value: 0xbeefefee };
+        let data4 = MyData { value: 0xdeaddead };
+        let data5 = MyData { value: 0xdeadfead };
+
+        assert!(!sparse_set.contains_key(entity1));
+        assert!(!sparse_set.contains_key(entity3));
+        assert!(!sparse_set.contains_key(entity2));
+        assert!(!sparse_set.contains_key(entity4));
+
+        let already_present = sparse_set.insert(entity1, data1);
+        assert!(!already_present);
+
+        let already_present = sparse_set.insert(entity2, data2);
+        assert!(!already_present);
+        let already_present = sparse_set.insert(entity3, data3);
+        assert!(!already_present);
+        let already_present = sparse_set.insert(entity4, data4);
+        assert!(!already_present);
+        let already_present = sparse_set.insert(entity4_new, data5);
+        assert!(!already_present);
+
+        let serialized = bincode::serialize(&sparse_set).unwrap();
+        let deserialized: TypedSparseSet<MyEntityId, MyData> =
+            bincode::deserialize(&serialized).unwrap();
+
+        assert_eq!(deserialized.get(entity1).unwrap(), &data1);
+        assert_eq!(deserialized.get(entity2).unwrap(), &data2);
+        assert_eq!(deserialized.get(entity3).unwrap(), &data3);
+        assert!(!deserialized.contains_key(entity4));
+        assert_eq!(deserialized.get(entity4_new).unwrap(), &data5);
+        assert_eq!(deserialized.len(), 4);
+    }
+}

--- a/src/sparse_set/id.rs
+++ b/src/sparse_set/id.rs
@@ -1,0 +1,400 @@
+use core::marker::PhantomData;
+use core::num::NonZeroU32;
+use core::num::NonZeroU64;
+
+/// Implemented for id types that can be used as keys in [`TypedSparseSet`][super::TypedSparseSet]s.
+///
+/// Must track both an index and a version for each index.
+///
+/// You can generate types that implement this trait with the [`define_id!`] macro.
+pub trait SetId: std::fmt::Display + Copy {
+    fn as_raw(&self) -> RawId;
+    fn from_raw(raw: RawId) -> Self;
+    fn is_invalid(&self) -> bool;
+    fn is_server_id(&self) -> bool;
+    fn index(&self) -> usize;
+    fn version(&self) -> NonZeroU32;
+}
+
+pub type RawId = NonZeroU64;
+
+/// Create your own [`SetId`] type.
+///
+/// The id will be represented internally by a [`RawId`], with the following layout:
+///
+/// Lower 32 bits contain the main index
+/// Upper 31 bits contain nonzero version (i.e. beginning at 1)
+/// Final 1 highest bit contains client/server flag, where 1 means client.
+///
+/// The server tag is 0 so that server ids can be encoded efficiently as two
+/// varints, one for low 32 bits and one for high 32 bits. Add `#[with_speedy]` as seen in example below
+/// to implement this through `speedy` (you'll need to add `speedy` as a dependency
+/// in the crate you use this macro for it to work).
+///
+/// # Example
+///
+/// ```
+/// kollect::define_id! {
+///     /// Yay, my own Id!
+///     pub struct MyEntityId;
+/// }
+///
+/// kollect::define_id! {
+///     #[with_speedy] // must come before other meta...
+///     /// Wow, speedy impl!
+///     pub struct MyEntityIdWithSpeedy;
+/// }
+/// ```
+#[macro_export]
+macro_rules! define_id {
+    {
+        #[with_speedy]
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident;
+    } => {
+$crate::define_id! {
+    $(#[$meta])*
+    $vis struct $name;
+}
+
+const _: () = {
+    use $crate::sparse_set::RawId;
+
+    impl<'a, C> speedy::Readable<'a, C> for $name
+    where
+        C: speedy::Context,
+    {
+        #[inline]
+        fn read_from<R: speedy::Reader<'a, C>>(reader: &mut R) -> Result<Self, C::Error> {
+            let upper = reader.read_u64_varint()?;
+            let lower = reader.read_u64_varint()?;
+
+            Ok(Self {
+                raw: RawId::new((upper << 32) | lower).expect("nonzero id"),
+            })
+        }
+
+        #[inline]
+        fn minimum_bytes_needed() -> usize {
+            1
+        }
+    }
+
+    impl<C> speedy::Writable<C> for $name
+    where
+        C: speedy::Context,
+    {
+        #[inline]
+        fn write_to<T: ?Sized + speedy::Writer<C>>(&self, writer: &mut T) -> Result<(), C::Error> {
+            let upper = self.raw.get() >> 32;
+            let lower = self.raw.get() & 0xffff_ffff;
+            writer.write_u64_varint(upper)?;
+            writer.write_u64_varint(lower)?;
+            Ok(())
+        }
+
+        #[inline]
+        fn bytes_needed(&self) -> Result<usize, C::Error> {
+            use speedy::private::VarInt64;
+            use speedy::Writable;
+            let upper: VarInt64 = (self.raw.get() >> 32).into();
+            let lower: VarInt64 = (self.raw.get() & 0xffff_ffff).into();
+            Ok(<VarInt64 as Writable<C>>::bytes_needed(&upper)?
+                + <VarInt64 as Writable<C>>::bytes_needed(&lower)?)
+        }
+    }
+};
+
+    };
+
+    {
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident;
+    } => {
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+$(#[$meta])*
+pub struct $name {
+    raw: $crate::sparse_set::RawId,
+}
+
+const _: () = {
+    use std::num::NonZeroU32;
+    use $crate::sparse_set::SetId;
+    use $crate::sparse_set::RawId;
+
+    impl SetId for $name {
+        #[inline(always)]
+        fn as_raw(&self) -> RawId {
+            self.as_raw()
+        }
+
+        #[inline(always)]
+        fn from_raw(raw: RawId) -> Self {
+            Self::from_raw_checked(raw)
+        }
+
+        #[inline(always)]
+        fn is_invalid(&self) -> bool {
+            self == &Self::invalid()
+        }
+
+        #[inline(always)]
+        fn index(&self) -> usize {
+            self.index()
+        }
+
+        #[inline(always)]
+        fn version(&self) -> NonZeroU32 {
+            self.version()
+        }
+
+        #[inline(always)]
+        fn is_server_id(&self) -> bool {
+            self.is_server_id()
+        }
+    }
+
+    impl std::fmt::Debug for $name {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            if self.is_server_id() {
+                write!(f, "server({}v{})", self.index(), self.version().get())
+            } else {
+                write!(f, "client({}v{})", self.index(), self.version().get())
+            }
+        }
+    }
+
+    impl std::fmt::Display for $name {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self)
+        }
+    }
+
+    #[allow(dead_code)]
+    impl $name {
+        #[inline]
+        pub const fn invalid() -> Self {
+            Self {
+                // SAFETY: Invalid is non-zero.
+                raw: unsafe { RawId::new_unchecked(0x0000_0001_FFFF_FFFF) },
+            }
+        }
+
+        #[inline]
+        pub const fn as_raw(&self) -> RawId {
+            self.raw
+        }
+
+        #[inline]
+        const fn try_get_version(repr: u64) -> Option<NonZeroU32> {
+            NonZeroU32::new(((repr >> 32) as u32) & 0x7FFF_FFFF)
+        }
+
+        /// # Safety
+        ///
+        /// must ensure version in the given RawId is nonzero
+        #[inline]
+        unsafe fn get_version_unchecked(raw: RawId) -> NonZeroU32 {
+            // SAFETY: version being nonzero is checked at construction time
+            unsafe { NonZeroU32::new_unchecked(((raw.get() >> 32) as u32) & 0x7FFF_FFFF) }
+        }
+
+        #[inline]
+        pub const fn from_u64(repr: u64) -> Self {
+            // Layout of id is:
+            // Upper 32-bits a non-zero version,
+            // Lower 32-bits an "index".
+
+            if Self::try_get_version(repr).is_none() {
+                panic!("Expected non-zero version!");
+            }
+            Self {
+                // SAFETY: Version is already non-zero
+                raw: unsafe { RawId::new_unchecked(repr) },
+            }
+        }
+
+        #[inline]
+        pub fn from_raw_checked(repr: RawId) -> Self {
+            let _validate = Self::try_get_version(repr.get()).expect("Expected non-zero version!");
+
+            Self { raw: repr }
+        }
+
+        /// Make a new server id from index and version. Version must be nonzero.
+        #[inline]
+        pub fn from_index_and_version_server(index: usize, version: u32) -> Self {
+            assert!(version != 0);
+            Self {
+                // SAFETY: Version is non-zero
+                raw: unsafe {
+                    RawId::new_unchecked(
+                        (((version as u64) & 0x7FFF_FFFF) << 32) | (index as u64),
+                    )
+                },
+            }
+        }
+
+        /// Make a new (client/standalone) id from index and version. Version must be nonzero.
+        #[inline]
+        pub fn from_index_and_version(index: usize, version: u32) -> Self {
+            let mut id = Self::from_index_and_version_server(index, version);
+            id.raw |= (1 << 63);
+            id
+        }
+
+        #[inline]
+        pub fn version(&self) -> NonZeroU32 {
+            // SAFETY: This is already verified at construction time.
+            unsafe { Self::get_version_unchecked(self.raw) }
+        }
+
+        #[inline]
+        pub fn index(&self) -> usize {
+            (self.raw.get() & 0xffff_ffff) as usize
+        }
+
+        #[inline]
+        pub fn is_server_id(&self) -> bool {
+            (self.raw.get() & (1 << 63)) == 0
+        }
+
+        #[inline]
+        pub fn is_client_id(&self) -> bool {
+            !self.is_server_id()
+        }
+    }
+};
+
+    };
+}
+
+/// Allocator for [`SetId`]s.
+///
+/// This is separated from the [`TypedSparseSet`][super::TypedSparseSet]
+/// itself so that id allocation can be decoupled from concrete sets themselves.
+///
+/// It is aware of in what context it is running (client/server) in order to allocate client ids
+/// that won't collide with the ids allocated on the server and vice-versa.
+/// The top bit indicates if it's a server or client id, with 1 indicating client and 0 indicating
+/// server. This is designed to work with id types generated via [`define_id!`].
+#[derive(Debug, Clone)]
+pub struct IdAllocator<T> {
+    // Indices
+    free: Vec<u32>,
+
+    // Versions
+    slots: Vec<NonZeroU32>,
+
+    // Are we running as a server or in client/standalone mode.
+    is_server: bool,
+
+    _phantom: PhantomData<fn() -> T>
+}
+
+impl<T: SetId> IdAllocator<T> {
+    pub fn new_client_or_standalone() -> Self {
+        Self {
+            free: Vec::new(),
+            slots: Vec::new(),
+            is_server: false,
+            _phantom: PhantomData,
+        }
+    }
+    pub fn new_server() -> Self {
+        Self {
+            free: Vec::new(),
+            slots: Vec::new(),
+            is_server: false,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Allocate a new id
+    ///
+    /// Reuses previously freed slots, then allocates new ones if there are no free slots available
+    pub fn allocate(&mut self) -> T {
+        let entity_id = if let Some(free_idx) = self.free.pop() {
+            let slot_version = &mut self.slots[free_idx as usize];
+            let new_version = (*slot_version).checked_add(1).expect("version shouldnt overflow");
+            assert!(new_version.get() != 0xffff_ffff);
+            *slot_version = new_version;
+
+            let new_version = if self.is_server {
+                new_version.get()
+            } else {
+                new_version.get() | (1 << 31)
+            };
+
+            // SAFETY: version is nonzero
+            let raw = unsafe { RawId::new_unchecked(((new_version as u64) << 32) | free_idx as u64) };
+
+            T::from_raw(raw)
+        } else {
+            let idx = self.slots.len();
+
+            // SAFETY: 1 is not 0
+            self.slots.push(unsafe { NonZeroU32::new_unchecked(1) });
+
+            let version = if self.is_server { 1 } else { 1 | (1 << 31) };
+
+            // SAFETY: version is nonzero
+            let raw = unsafe { RawId::new_unchecked(((version as u64) << 32) | idx as u64) };
+
+            T::from_raw(raw)
+        };
+
+        entity_id
+    }
+
+    /// Remove an id. Returns true if successfully removed, false if the id didn't exist so didn't
+    /// remove anything.
+    pub fn remove(&mut self, id: T) -> bool {
+        let version = id.version();
+        let index = id.index();
+
+        if let Some(slot) = self.slots.get_mut(index as usize) {
+            if slot.get() & 0x7FFF_FFFF == version.get() {
+                self.free.push(index as u32);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Returns true if the id currently exists
+    pub fn contains(&self, id: T) -> bool {
+        let version = id.version();
+        let index = id.index();
+        self.slots.get(index as usize).copied() == Some(version)
+    }
+
+    /// Removes all currently allocated ids, leaving empty slots in their place.
+    pub fn clear(&mut self) {
+        for (idx, _) in self.slots[..].iter().enumerate() {
+            self.free.push(idx as u32);
+        }
+
+        if !self.is_server {
+            self.free.sort();
+            self.free.reverse();
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    define_id! {
+        struct BaseId;
+    }
+
+    #[cfg(feature = "speedy")]
+    define_id! {
+        #[with_speedy]
+        struct SpeedyId;
+    }
+}

--- a/src/sparse_set/networked_set.rs
+++ b/src/sparse_set/networked_set.rs
@@ -1,0 +1,297 @@
+use std::ops::Index;
+use std::ops::IndexMut;
+
+use super::{SetId, SparseSetIter, SparseSetIterMut, TypedSparseSet};
+
+#[derive(Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct NetworkedSet<K: SetId, V> {
+    server: TypedSparseSet<K, V>,
+    client: TypedSparseSet<K, V>,
+}
+
+impl<K: SetId, T> Default for NetworkedSet<K, T> {
+    fn default() -> Self {
+        Self {
+            server: Default::default(),
+            client: Default::default(),
+        }
+    }
+}
+
+impl<K: SetId, V: Default> NetworkedSet<K, V> {
+    /// Returns a reference to an existing element or inserts the default value
+    /// and returns a reference to that.
+    pub fn get_or_insert_default(&mut self, id: K) -> &V {
+        if self.contains_key(id) {
+            // SAFETY: We just checked existence
+            return unsafe { self.get(id).unwrap_unchecked() };
+        }
+        self.insert(id, Default::default());
+        // SAFETY: We just inserted the key
+        unsafe { self.get(id).unwrap_unchecked() }
+    }
+
+    /// Returns a mutable reference to an existing element or inserts the default value
+    /// and returns a mutable reference to that.
+    pub fn get_mut_or_insert_default(&mut self, id: K) -> &mut V {
+        if self.contains_key(id) {
+            // SAFETY: We just checked existence
+            return unsafe { self.get_mut(id).unwrap_unchecked() };
+        }
+        self.insert(id, Default::default());
+        // SAFETY: We just inserted the key
+        unsafe { self.get_mut(id).unwrap_unchecked() }
+    }
+
+    // Returns a mutable reference to an existing element or inserts the default value if the value didn't exist
+    // or is newer than the existing one. Otherwise it returns `None`.
+    pub fn try_get_mut_or_insert_default(&mut self, id: K) -> Option<&mut V> {
+        if self.is_older_than_existing(id) {
+            None
+        } else {
+            Some(self.get_mut_or_insert_default(id))
+        }
+    }
+}
+
+impl<K: SetId, V> NetworkedSet<K, V> {
+    pub fn client(&self) -> &TypedSparseSet<K, V> {
+        &self.client
+    }
+
+    pub fn client_mut(&mut self) -> &mut TypedSparseSet<K, V> {
+        &mut self.client
+    }
+
+    pub fn server(&self) -> &TypedSparseSet<K, V> {
+        &self.server
+    }
+
+    pub fn server_mut(&mut self) -> &mut TypedSparseSet<K, V> {
+        &mut self.server
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            server: TypedSparseSet::with_capacity(capacity),
+            client: TypedSparseSet::with_capacity(capacity),
+        }
+    }
+
+    /// Returns `true` if the sparse set contains a value for the given id.
+    #[inline]
+    pub fn contains_key(&self, id: K) -> bool {
+        if id.is_server_id() {
+            self.server.contains_key(id)
+        } else {
+            self.client.contains_key(id)
+        }
+    }
+
+    #[inline]
+    pub fn is_older_than_existing(&self, id: K) -> bool {
+        if id.is_server_id() {
+            self.server.is_older_than_existing(id)
+        } else {
+            self.client.is_older_than_existing(id)
+        }
+    }
+
+    /// Clears the sparse set storage, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the sparse set.
+    pub fn clear(&mut self) {
+        self.server.clear();
+        self.client.clear();
+    }
+
+    /// Returns a reference to an element in the sparse set.
+    pub fn get(&self, id: K) -> Option<&V> {
+        if id.is_server_id() {
+            self.server.get(id)
+        } else {
+            self.client.get(id)
+        }
+    }
+
+    /// Returns a mutable reference to an element in the sparse set.
+    pub fn get_mut(&mut self, id: K) -> Option<&mut V> {
+        if id.is_server_id() {
+            self.server.get_mut(id)
+        } else {
+            self.client.get_mut(id)
+        }
+    }
+
+    /// Inserts the `id` key and `value` into this sparse set.
+    ///
+    /// Returns `true` when the key was already present in the sparse set
+    /// otherwise `false`.
+    ///
+    /// Will panic if the key is older than the existing key in the set.
+    /// Use `insert_ignore_old_key` if you want to silently skip insertion
+    /// for older keys instead of panicking.
+    pub fn insert(&mut self, id: K, value: V) -> bool {
+        if id.is_server_id() {
+            self.server.insert(id, value)
+        } else {
+            self.client.insert(id, value)
+        }
+    }
+
+    /// Inserts the `id` key and `value` into this sparse set.
+    ///
+    /// Returns `true` when the key was already present in the sparse set
+    /// otherwise `false`.
+    ///
+    /// Use `insert` if you want to assert that the key is newer or the same
+    /// version as the exiting keys.
+    pub fn insert_ignore_old_key(&mut self, id: K, value: V) -> bool {
+        if id.is_server_id() {
+            self.server.insert_ignore_old_key(id, value)
+        } else {
+            self.client.insert_ignore_old_key(id, value)
+        }
+    }
+
+    /// Removes the id from this sparse set and returns the removed element.
+    pub fn remove(&mut self, id: K) -> Option<V> {
+        if id.is_server_id() {
+            self.server.remove(id)
+        } else {
+            self.client.remove(id)
+        }
+    }
+
+    /// Unsafely returns a mutable reference to an element in the sparse set.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that there is no *mutable* access to the entire `data` storage
+    /// as a whole is only *shared*, **and** that the access to the specific id's data is
+    /// unique (no active references, mutable or not).
+    #[inline]
+    pub unsafe fn get_mut_unchecked(&self, id: K) -> Option<&mut V> {
+        if id.is_server_id() {
+            // SAFETY: Same as function-level safety
+            unsafe { self.server.get_mut_unchecked(id) }
+        } else {
+            // SAFETY: Same as function-level safety
+            unsafe { self.client.get_mut_unchecked(id) }
+        }
+    }
+
+    /// Unsafely inserts the `id` key and `value` into this sparse set.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that access to the _entire_ `data` store as well as the `dense` id store are unique
+    /// (no active references, mutable or not). This is required as the insert can cause reallocations, making existing
+    /// references invalid.
+    #[inline]
+    pub unsafe fn insert_unchecked(&self, id: K, value: V) -> bool {
+        if id.is_server_id() {
+            // SAFETY: Same as function-level safety
+            unsafe { self.server.insert_unchecked(id, value) }
+        } else {
+            // SAFETY: Same as function-level safety
+            unsafe { self.client.insert_unchecked(id, value) }
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.server.is_empty() && self.client.is_empty()
+    }
+
+    #[inline]
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.server.keys().iter().chain(self.client.keys().iter())
+    }
+
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.iter().map(|(_, v)| v)
+    }
+
+    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
+        self.iter_mut().map(|(_, v)| v)
+    }
+
+    pub fn len(&self) -> usize {
+        self.server.len() + self.client.len()
+    }
+
+    #[inline]
+    pub fn iter(&self) -> SparseSetIter<'_, K, V> {
+        SparseSetIter::new_chained(&self.server, &self.client)
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> SparseSetIterMut<'_, K, V> {
+        SparseSetIterMut::new_chained(&mut self.server, &mut self.client)
+    }
+
+    pub fn retain(&mut self, mut fun: impl FnMut(K, &mut V) -> bool) {
+        // This is shit
+        // TODO (nummelin): Optimize :)
+        let mut to_remove = Vec::new();
+        for (ent, val) in self.iter_mut() {
+            if !fun(ent, val) {
+                to_remove.push(ent);
+            }
+        }
+        for ent in to_remove {
+            self.remove(ent);
+        }
+    }
+}
+
+impl<'a, K: SetId, V: 'a + Copy> NetworkedSet<K, V> {
+    /// Extends the set but ignores any older keys silently. Use `extend`
+    /// if you want to assert that all data is inserted.
+    pub fn extend_ignore_old_keys<I: IntoIterator<Item = (K, &'a V)>>(&mut self, iter: I) {
+        let iter = iter.into_iter();
+        for (k, v) in iter {
+            self.insert_ignore_old_key(k, *v);
+        }
+    }
+}
+
+impl<K: SetId, V> Index<K> for NetworkedSet<K, V> {
+    type Output = V;
+
+    fn index(&self, index: K) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+
+impl<K: SetId, V> IndexMut<K> for NetworkedSet<K, V> {
+    fn index_mut(&mut self, index: K) -> &mut Self::Output {
+        self.get_mut(index).unwrap()
+    }
+}
+
+impl<'a, K: SetId, V: 'a + Copy> Extend<(K, &'a V)> for NetworkedSet<K, V> {
+    fn extend<I: IntoIterator<Item = (K, &'a V)>>(&mut self, iter: I) {
+        let iter = iter.into_iter();
+        for (k, v) in iter {
+            self.insert(k, *v);
+        }
+    }
+}
+
+impl<K: SetId, V> FromIterator<(K, V)> for NetworkedSet<K, V>
+where
+    K: SetId,
+{
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let iter = iter.into_iter();
+        let mut d = Self::default();
+        for (k, v) in iter {
+            d.insert(k, v);
+        }
+        d
+    }
+}


### PR DESCRIPTION
- Adds `TypedSparseSet`, the main sparse set implementation + `NetworkedSet` which combines two sparse sets with the same id type but different key spaces for the case of client + server replication
- Adds `IdAllocator` for allocating ids into `TypedSparseSet`/`NetworkedSet`
- Adds `SetId` trait + `define_id!` macro to create your own id types